### PR TITLE
Fix incorrect node version parameter

### DIFF
--- a/install-browser/action.yaml
+++ b/install-browser/action.yaml
@@ -37,7 +37,7 @@ runs:
       uses: actions/setup-node@v3
       if: ${{ contains(inputs.browser, 'node') || inputs.runner == 'playwright' }}
       with:
-        node-version: ${{ inputs.driver-version }}
+        node-version: ${{ inputs.browser-version }}
 
     - name: Cache Playwright browsers
       uses: actions/cache@v3


### PR DESCRIPTION
There was a typo in the `install-browser` action, which caused pytest-pyodide to always install and test with the latest version of node.