### PR TITLE
Reindent `with:` in YAML @ README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Github Actions snippets for Pyodide
 steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
-    with:
+      with:
         python-version: "3.10"
     - uses: pyodide/pyodide-actions/install-browser
-    with:
+      with:
         runner: selenium
         browser: chrome
         browser-version: latest
@@ -37,7 +37,7 @@ steps:
 steps:
     - uses: actions/checkout@v3
     - uses: pyodide/pyodide-actions/download-pyodide
-    with:
+      with:
         version: 0.21.0
         to: dist
 ```


### PR DESCRIPTION
The YAML examples had all `with:` lines lacking two spaces in their indentation, effectively presenting broken YAML snippets. This patch corrects that by applying the correct indentation.