### PR TITLE
Use install-chromedriver option for chromedriver installation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
             os: "ubuntu-latest",
             runner: "selenium",
             browser: "node",
-            browser-version: "18",
+            browser-version: "22",
           },
           {
             os: "macos-latest",
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - uses: ./install-browser
         with:
           runner: ${{ matrix.test-config.runner }}
@@ -74,13 +74,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [0.21.3, 0.22.1, 0.23.2]
+        version: [0.23.2, 0.24.0, 0.25.0, 0.26.0]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - uses: ./download-pyodide
         with:
           version: ${{ matrix.version }}
@@ -98,5 +98,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - uses: pre-commit/action@v3.0.0

--- a/install-browser/action.yaml
+++ b/install-browser/action.yaml
@@ -76,10 +76,7 @@ runs:
       if: ${{ inputs.runner == 'selenium' && contains(inputs.browser, 'chrome') }}
       with:
         chrome-version: ${{ inputs.browser-version }}
-
-    - name: Install chromedriver
-      if: ${{ inputs.runner == 'selenium' && contains(inputs.browser, 'chrome') }}
-      uses: nanasess/setup-chromedriver@v2
+        install-chromedriver: true
 
     - name: Enable Safari Driver
       shell: bash -l {0}


### PR DESCRIPTION
Instead of using separate action to install the chromedriver, use `install-chromedriver` option in `browser-actions/setup-chrome` to install the compatible version of chromedriver.

I am trying to fix the Chrome timeout issues at https://github.com/pyodide/micropip/pull/129. Not sure if this works, but it is worth to try.