### PR TITLE
Overwrite system chrome to handle version mismatch

### DIFF
--- a/install-browser/action.yaml
+++ b/install-browser/action.yaml
@@ -72,11 +72,21 @@ runs:
         token: ${{ inputs.github-token }}
 
     - name: Install chrome
+      id: chrome
       uses: browser-actions/setup-chrome@latest
       if: ${{ inputs.runner == 'selenium' && contains(inputs.browser, 'chrome') }}
       with:
         chrome-version: ${{ inputs.browser-version }}
         install-chromedriver: true
+    
+    - name: Overwrite system Chrome and ChromeDriver
+      shell: bash -l {0}
+      if: ${{ inputs.runner == 'selenium' && contains(inputs.browser, 'chrome') }}
+      run: |
+        sudo rm -f /usr/bin/google-chrome
+        sudo rm -f /usr/bin/chromedriver
+        sudo ln -s ${{ steps.setup-chrome.outputs.chrome-path }} /usr/bin/google-chrome
+        sudo ln -s ${{ steps.setup-chrome.outputs.chromedriver-path }} /usr/bin/chromedriver
 
     - name: Enable Safari Driver
       shell: bash -l {0}

--- a/install-browser/action.yaml
+++ b/install-browser/action.yaml
@@ -85,8 +85,8 @@ runs:
       run: |
         sudo rm -f /usr/bin/google-chrome
         sudo rm -f /usr/bin/chromedriver
-        sudo ln -s ${{ steps.setup-chrome.outputs.chrome-path }} /usr/bin/google-chrome
-        sudo ln -s ${{ steps.setup-chrome.outputs.chromedriver-path }} /usr/bin/chromedriver
+        sudo ln -s ${{ steps.chrome.outputs.chrome-path }} /usr/bin/google-chrome
+        sudo ln -s ${{ steps.chrome.outputs.chromedriver-path }} /usr/bin/chromedriver
 
     - name: Enable Safari Driver
       shell: bash -l {0}

--- a/install-browser/action.yaml
+++ b/install-browser/action.yaml
@@ -78,7 +78,7 @@ runs:
       with:
         chrome-version: ${{ inputs.browser-version }}
         install-chromedriver: true
-    
+
     - name: Overwrite system Chrome and ChromeDriver
       shell: bash -l {0}
       if: ${{ inputs.runner == 'selenium' && contains(inputs.browser, 'chrome') }}


### PR DESCRIPTION
GHA ubuntu runner has a system google-chrome installed in /usr/bin/google-chrome, which shadows the chrome installed by `browser-actions/setup-chrome`.