### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directories: 
+    directories:
       - "/.github/workflows"
       - "/download-pyodide"
       - "/install-browser"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directories: 
+      - "/.github/workflows"
+      - "/download-pyodide"
+      - "/install-browser"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
I added a config file for dependabot so that the actions that are reused (as well as the ones in the workflows) stay up to date.

For example, this version was deprecated, so one always gets warnings in the CI logs.
https://github.com/pyodide/pyodide-actions/blob/012fa537869d343726d01863a34b773fc4d96a14/download-pyodide/action.yaml#L14